### PR TITLE
Add gitignore for binaries and editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Compiled binary outputs
+*.elf
+*.bin
+.pio/
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp
+*~
+.DS_Store
+


### PR DESCRIPTION
## Summary
- avoid committed build outputs and local IDE files by adding `.gitignore`

## Testing
- `npm test` *(fails: package.json missing)*